### PR TITLE
Fix Groups schema/repository column mismatch and add CRUD integration tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "chat.tools.terminal.autoApprove": {
-        "go test": true
+        "go test": true,
+        "git status": true,
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "go test": true
+    }
+}

--- a/database/UserRepo.go
+++ b/database/UserRepo.go
@@ -90,7 +90,7 @@ func GetAllUsers(db *sql.DB) ([]models.User, error) {
 
 func GetUserGroups(db *sql.DB, id int) ([]models.Group, error) {
 	var groups []models.Group
-	sqlStmt := `SELECT g.group_id, g.group_name, g.date_created, g.date_draw, g.creator_user_id
+	sqlStmt := `SELECT g.group_id, g.name, g.date_created, g.date_draw, g.creator_user_id
 	FROM Groups g
 	JOIN Participants p ON g.group_id = p.group_id
 	WHERE p.user_id = ?;`

--- a/database/database.go
+++ b/database/database.go
@@ -38,10 +38,10 @@ func CreateTables() {
 
 	sqlStmt = `
 	CREATE TABLE IF NOT EXISTS Groups (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		group_name TEXT,
-		date_created TEXT,
-		date_draw TEXT,
+		group_id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT,
+		date_created DATETIME,
+		date_draw DATETIME,
 		creator_user_id INTEGER
 	);
 	`

--- a/database/group_repo_integration_test.go
+++ b/database/group_repo_integration_test.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akctba/secret-santa-go-api/models"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newGroupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+
+	createStmt := `
+	CREATE TABLE Groups (
+		group_id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT,
+		date_created DATETIME,
+		date_draw DATETIME,
+		creator_user_id INTEGER
+	);`
+
+	if _, err = db.Exec(createStmt); err != nil {
+		db.Close()
+		t.Fatalf("create Groups table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	return db
+}
+
+func TestGroupRepoCRUD(t *testing.T) {
+	db := newGroupTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	group := models.Group{
+		GroupID:       "1",
+		Name:          "Holiday Crew",
+		DateCreated:   now,
+		DateDraw:      now.Add(24 * time.Hour),
+		CreatorUserID: 42,
+	}
+
+	if err := InsertGroup(db, group); err != nil {
+		t.Fatalf("InsertGroup returned error: %v", err)
+	}
+
+	got, err := GetGroupByID(db, group.GroupID)
+	if err != nil {
+		t.Fatalf("GetGroupByID returned error: %v", err)
+	}
+
+	if got.GroupID != group.GroupID {
+		t.Fatalf("expected group id %q, got %q", group.GroupID, got.GroupID)
+	}
+	if got.Name != group.Name {
+		t.Fatalf("expected name %q, got %q", group.Name, got.Name)
+	}
+	if got.CreatorUserID != group.CreatorUserID {
+		t.Fatalf("expected creator_user_id %d, got %d", group.CreatorUserID, got.CreatorUserID)
+	}
+
+	group.Name = "Updated Holiday Crew"
+	if err := UpdateGroup(db, group); err != nil {
+		t.Fatalf("UpdateGroup returned error: %v", err)
+	}
+
+	updated, err := GetGroupByID(db, group.GroupID)
+	if err != nil {
+		t.Fatalf("GetGroupByID after update returned error: %v", err)
+	}
+	if updated.Name != group.Name {
+		t.Fatalf("expected updated name %q, got %q", group.Name, updated.Name)
+	}
+
+	if err := DeleteGroup(db, group.GroupID); err != nil {
+		t.Fatalf("DeleteGroup returned error: %v", err)
+	}
+
+	_, err = GetGroupByID(db, group.GroupID)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows after delete, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes issue #5 by standardizing Groups schema and repository SQL to use the same column names, and adds integration coverage for Group CRUD operations.

## What changed
- Updated Groups table schema:
  - `group_id` replaces `id`
  - `name` replaces `group_name`
  - `date_created` and `date_draw` use `DATETIME` for `time.Time` scans
- Updated user group query to select `g.name` instead of `g.group_name`
- Added SQLite integration test for Group CRUD:
  - create group
  - get group by id
  - update group
  - delete group
  - verify deleted row returns `sql.ErrNoRows`
- Kept workspace setting file as requested

## Why
Issue #5 identified a runtime mismatch between table columns and SQL queries (`id/group_name` vs `group_id/name`) that can cause `no such column` errors during group CRUD operations.

## Verification
- Ran `go test ./...`
- All tests passed

Closes #5