### PR TITLE
Harden request validation and hide password fields

### DIFF
--- a/controllers/db_failure_test.go
+++ b/controllers/db_failure_test.go
@@ -54,7 +54,7 @@ func TestHandlersReturnInternalServerErrorWhenDBUnavailable(t *testing.T) {
 			handler: CreateGroup,
 			method:  http.MethodPost,
 			path:    "/group",
-			body:    `{"group_name":"xmas"}`,
+			body:    `{"name":"xmas"}`,
 		},
 		{
 			name:    "GetGroup returns 500 on DB failure",

--- a/controllers/group.go
+++ b/controllers/group.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	randv2 "math/rand/v2"
 	"net/http"
+	"strings"
 
 	"github.com/akctba/secret-santa-go-api/database"
 	"github.com/akctba/secret-santa-go-api/models"
@@ -28,7 +29,16 @@ func (cryptoSource) Uint64() uint64 {
 // CreateGroup handles POST /group. Persists a new group to the database.
 func CreateGroup(w http.ResponseWriter, r *http.Request) {
 	var group models.Group
-	json.NewDecoder(r.Body).Decode(&group)
+	if err := json.NewDecoder(r.Body).Decode(&group); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	group.Name = strings.TrimSpace(group.Name)
+	if group.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
 
 	db, err := getDB()
 	if err != nil {
@@ -77,7 +87,16 @@ func AddParticipant(w http.ResponseWriter, r *http.Request) {
 	groupID := vars["id"]
 
 	var request models.ParticipantRequest
-	json.NewDecoder(r.Body).Decode(&request)
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	request.GroupID = strings.TrimSpace(request.GroupID)
+	if request.GroupID == "" || request.UserID <= 0 {
+		http.Error(w, "group_id and user_id are required", http.StatusBadRequest)
+		return
+	}
 
 	db, err := getDB()
 	if err != nil {

--- a/controllers/request_validation_test.go
+++ b/controllers/request_validation_test.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestSigninReturnsBadRequestForMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/user/signin", strings.NewReader(`{"email":"alice@example.com",`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	Signin(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
+func TestSigninReturnsBadRequestForMissingFields(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/user/signin", strings.NewReader(`{"email":"","password":""}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	Signin(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "email and password are required") {
+		t.Fatalf("expected missing fields error, got: %s", rr.Body.String())
+	}
+}
+
+func TestCreateGroupReturnsBadRequestForMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/group", strings.NewReader(`{"name":"xmas"`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	CreateGroup(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
+func TestAddParticipantReturnsBadRequestForMissingFields(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/group/1/participant", strings.NewReader(`{"group_id":"","user_id":0}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+
+	rr := httptest.NewRecorder()
+	AddParticipant(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "group_id and user_id are required") {
+		t.Fatalf("expected missing fields error, got: %s", rr.Body.String())
+	}
+}

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/akctba/secret-santa-go-api/auth"
 	"github.com/akctba/secret-santa-go-api/database"
@@ -20,10 +21,43 @@ type createUserRequest struct {
 	Password string `json:"password"`
 }
 
+type userResponse struct {
+	UserID      int       `json:"user_id"`
+	UserName    string    `json:"user_name"`
+	UserEmail   string    `json:"user_email"`
+	Gender      string    `json:"gender"`
+	DateOfBirth time.Time `json:"date_of_birth"`
+}
+
+func toUserResponse(user models.User) userResponse {
+	resp := userResponse{
+		UserID:      user.UserID,
+		UserName:    user.UserName,
+		UserEmail:   user.UserEmail,
+		Gender:      user.Gender,
+		DateOfBirth: user.DateOfBirth,
+	}
+
+	return resp
+}
+
 // Signin handles POST /user/signin. Validates credentials and returns a bearer token.
 func Signin(w http.ResponseWriter, r *http.Request) {
 	var request models.UserSignin
-	json.NewDecoder(r.Body).Decode(&request)
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	email := strings.TrimSpace(request.UserEmail)
+	password := strings.TrimSpace(request.Password)
+	if email == "" || password == "" {
+		http.Error(w, "email and password are required", http.StatusBadRequest)
+		return
+	}
+
+	request.UserEmail = email
+	request.Password = password
 
 	db, err := getDB()
 	if err != nil {
@@ -101,7 +135,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(user)
+	json.NewEncoder(w).Encode(toUserResponse(user))
 }
 
 // GetUser handles GET /user/{id}. Returns the user with the given ID.
@@ -128,5 +162,5 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(user)
+	json.NewEncoder(w).Encode(toUserResponse(user))
 }

--- a/controllers/user_contract_test.go
+++ b/controllers/user_contract_test.go
@@ -1,0 +1,110 @@
+package controllers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupUserContractTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+
+	createUsersTable := `
+	CREATE TABLE Users (
+		user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_name TEXT,
+		user_email TEXT,
+		password TEXT,
+		gender TEXT,
+		date_of_birth TEXT
+	);`
+
+	if _, err := db.Exec(createUsersTable); err != nil {
+		db.Close()
+		t.Fatalf("create Users table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func withTestDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	originalGetDB := getDB
+	getDB = func() (*sql.DB, error) {
+		return db, nil
+	}
+
+	t.Cleanup(func() {
+		getDB = originalGetDB
+	})
+}
+
+func decodeJSONBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode json body: %v, body: %s", err, body)
+	}
+	return payload
+}
+
+func TestCreateUserResponseOmitsPassword(t *testing.T) {
+	db := setupUserContractTestDB(t)
+	withTestDB(t, db)
+
+	req := httptest.NewRequest(http.MethodPost, "/user", strings.NewReader(`{"user_name":"Alice","email":"alice@example.com","password":"secret123"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	CreateUser(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONBody(t, rr.Body.String())
+	if _, ok := payload["password"]; ok {
+		t.Fatalf("expected response to omit password, got: %s", rr.Body.String())
+	}
+}
+
+func TestGetUserResponseOmitsPassword(t *testing.T) {
+	db := setupUserContractTestDB(t)
+	withTestDB(t, db)
+
+	if _, err := db.Exec(`INSERT INTO Users (user_id, user_name, user_email, password) VALUES (1, 'Alice', 'alice@example.com', 'hashed-password')`); err != nil {
+		t.Fatalf("insert test user: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+
+	rr := httptest.NewRecorder()
+	GetUser(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONBody(t, rr.Body.String())
+	if _, ok := payload["password"]; ok {
+		t.Fatalf("expected response to omit password, got: %s", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
This PR improves API input validation and removes sensitive password data from user API responses.

## Changes
- Stop exposing `password` in user response payloads by returning a safe response DTO.
- Validate JSON decode errors in handlers and return `400 Bad Request` with clear messages.
- Validate required request fields for signin, group creation, and participant creation.
- Add contract tests asserting password is absent from user JSON responses.
- Add validation tests for malformed JSON and missing required fields.
- Update existing DB-failure test payload for `CreateGroup` to match current request contract.

## Verification
- `go test ./...` passes.

Closes #7