### PR TITLE
Fix JSON decode validation in request handlers

### DIFF
--- a/controllers/group.go
+++ b/controllers/group.go
@@ -29,7 +29,7 @@ func (cryptoSource) Uint64() uint64 {
 // CreateGroup handles POST /group. Persists a new group to the database.
 func CreateGroup(w http.ResponseWriter, r *http.Request) {
 	var group models.Group
-	if err := json.NewDecoder(r.Body).Decode(&group); err != nil {
+	if err := decodeRequestJSON(r, &group); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -87,7 +87,7 @@ func AddParticipant(w http.ResponseWriter, r *http.Request) {
 	groupID := vars["id"]
 
 	var request models.ParticipantRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := decodeRequestJSON(r, &request); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/controllers/request_decode.go
+++ b/controllers/request_decode.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+// decodeRequestJSON decodes a single JSON object and rejects unknown fields.
+func decodeRequestJSON(r *http.Request, dst any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("request body must contain only one json object")
+	}
+
+	return nil
+}

--- a/controllers/request_validation_test.go
+++ b/controllers/request_validation_test.go
@@ -57,6 +57,55 @@ func TestCreateGroupReturnsBadRequestForMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestCreateUserReturnsBadRequestForMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/user", strings.NewReader(`{"user_name":"alice",`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	CreateUser(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
+func TestAddParticipantReturnsBadRequestForMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/group/1/participant", strings.NewReader(`{"group_id":"1","user_id":`))
+	req.Header.Set("Content-Type", "application/json")
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+
+	rr := httptest.NewRecorder()
+	AddParticipant(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
+func TestCreateGroupReturnsBadRequestForUnknownField(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/group", strings.NewReader(`{"name":"xmas","unexpected":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	CreateGroup(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
 func TestAddParticipantReturnsBadRequestForMissingFields(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/group/1/participant", strings.NewReader(`{"group_id":"","user_id":0}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -44,7 +44,7 @@ func toUserResponse(user models.User) userResponse {
 // Signin handles POST /user/signin. Validates credentials and returns a bearer token.
 func Signin(w http.ResponseWriter, r *http.Request) {
 	var request models.UserSignin
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := decodeRequestJSON(r, &request); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -92,7 +92,7 @@ func Signin(w http.ResponseWriter, r *http.Request) {
 // CreateUser handles POST /user. Hashes the password and persists the new user.
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	var request createUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	if err := decodeRequestJSON(r, &request); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Summary
- add strict JSON decoding helper for request bodies
- return `400 Bad Request` when request JSON is malformed, contains unknown fields, or has extra objects
- apply strict decoding to user and group request handlers
- expand request validation tests for malformed and invalid payloads

Fixes #8