### PR TITLE
Implement GET /group/{id}/friend endpoint

### DIFF
--- a/controllers/group.go
+++ b/controllers/group.go
@@ -2,12 +2,15 @@ package controllers
 
 import (
 	"crypto/rand"
+	"database/sql"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	randv2 "math/rand/v2"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/akctba/secret-santa-go-api/database"
@@ -177,4 +180,49 @@ func RunDraw(w http.ResponseWriter, r *http.Request) {
 
 // GetSecretFriend handles GET /group/{id}/friend. Returns the authenticated user's assigned friend.
 func GetSecretFriend(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	groupID, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid group ID", http.StatusBadRequest)
+		return
+	}
+
+	userID, ok := authenticatedUserIDFromRequest(r)
+	if !ok {
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	db, err := getDB()
+	if err != nil {
+		log.Printf("failed to open db in GetSecretFriend: %v", err)
+		http.Error(w, "Failed to connect to database", http.StatusInternalServerError)
+		return
+	}
+	defer database.CloseDb(db)
+
+	participant, err := database.GetUserParticipant(db, userID, groupID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "User is not a participant of this group", http.StatusForbidden)
+			return
+		}
+
+		http.Error(w, "Failed to get participant", http.StatusInternalServerError)
+		return
+	}
+
+	if participant.FriendUserID == 0 {
+		http.Error(w, "Secret friend has not been drawn yet", http.StatusConflict)
+		return
+	}
+
+	friend, err := database.GetUserByID(db, participant.FriendUserID)
+	if err != nil {
+		http.Error(w, "Failed to get secret friend", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(toUserResponse(friend))
 }

--- a/controllers/group_friend_test.go
+++ b/controllers/group_friend_test.go
@@ -1,0 +1,162 @@
+package controllers
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akctba/secret-santa-go-api/auth"
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupGroupFriendTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+
+	createUsersTable := `
+	CREATE TABLE Users (
+		user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_name TEXT,
+		user_email TEXT,
+		password TEXT,
+		gender TEXT,
+		date_of_birth TEXT
+	);`
+	if _, err := db.Exec(createUsersTable); err != nil {
+		db.Close()
+		t.Fatalf("create Users table: %v", err)
+	}
+
+	createParticipantsTable := `
+	CREATE TABLE Participants (
+		group_id INTEGER,
+		user_id INTEGER,
+		joined_at TEXT,
+		friend_user_id INTEGER,
+		PRIMARY KEY (group_id, user_id)
+	);`
+	if _, err := db.Exec(createParticipantsTable); err != nil {
+		db.Close()
+		t.Fatalf("create Participants table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func TestGetSecretFriendReturnsAssignedFriend(t *testing.T) {
+	db := setupGroupFriendTestDB(t)
+	withTestDB(t, db)
+
+	_, err := db.Exec(`INSERT INTO Users (user_id, user_name, user_email, password) VALUES
+		(1, 'Alice', 'alice@example.com', 'secret'),
+		(2, 'Bob', 'bob@example.com', 'secret')`)
+	if err != nil {
+		t.Fatalf("insert users: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO Participants (group_id, user_id, joined_at, friend_user_id) VALUES (?, ?, ?, ?)`, 1, 1, time.Now().UTC().Format(time.RFC3339), 2)
+	if err != nil {
+		t.Fatalf("insert participant assignment: %v", err)
+	}
+
+	token, err := auth.CreateToken(1)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/group/1/friend", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	BearerAuth(GetSecretFriend)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONBody(t, rr.Body.String())
+	if payload["user_name"] != "Bob" {
+		t.Fatalf("expected friend user_name Bob, got payload: %s", rr.Body.String())
+	}
+	if _, ok := payload["password"]; ok {
+		t.Fatalf("expected response to omit password, got payload: %s", rr.Body.String())
+	}
+}
+
+func TestGetSecretFriendReturnsForbiddenForNonParticipant(t *testing.T) {
+	db := setupGroupFriendTestDB(t)
+	withTestDB(t, db)
+
+	_, err := db.Exec(`INSERT INTO Users (user_id, user_name, user_email, password) VALUES (1, 'Alice', 'alice@example.com', 'secret')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	token, err := auth.CreateToken(1)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/group/1/friend", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	BearerAuth(GetSecretFriend)(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusForbidden, rr.Code, rr.Body.String())
+	}
+
+	if !strings.Contains(rr.Body.String(), "User is not a participant of this group") {
+		t.Fatalf("expected not-participant error, got: %s", rr.Body.String())
+	}
+}
+
+func TestGetSecretFriendReturnsConflictWhenNotDrawn(t *testing.T) {
+	db := setupGroupFriendTestDB(t)
+	withTestDB(t, db)
+
+	_, err := db.Exec(`INSERT INTO Users (user_id, user_name, user_email, password) VALUES (1, 'Alice', 'alice@example.com', 'secret')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO Participants (group_id, user_id, joined_at) VALUES (?, ?, ?)`, 1, 1, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("insert participant without draw: %v", err)
+	}
+
+	token, err := auth.CreateToken(1)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/group/1/friend", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rr := httptest.NewRecorder()
+	BearerAuth(GetSecretFriend)(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusConflict, rr.Code, rr.Body.String())
+	}
+
+	if !strings.Contains(rr.Body.String(), "Secret friend has not been drawn yet") {
+		t.Fatalf("expected not-drawn error, got: %s", rr.Body.String())
+	}
+}

--- a/controllers/middleware.go
+++ b/controllers/middleware.go
@@ -1,11 +1,25 @@
 package controllers
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/akctba/secret-santa-go-api/auth"
 )
+
+type authContextKey string
+
+const authenticatedUserIDKey authContextKey = "authenticatedUserID"
+
+func authenticatedUserIDFromRequest(r *http.Request) (int, bool) {
+	userID, ok := r.Context().Value(authenticatedUserIDKey).(int)
+	if !ok {
+		return 0, false
+	}
+
+	return userID, true
+}
 
 // BearerAuth is middleware that validates a Bearer token in the Authorization header.
 func BearerAuth(next http.HandlerFunc) http.HandlerFunc {
@@ -17,12 +31,13 @@ func BearerAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		token := strings.TrimPrefix(authHeader, "Bearer ")
-		_, err := auth.ValidateToken(token)
+		userID, err := auth.ValidateToken(token)
 		if err != nil {
 			http.Error(w, "Invalid token", http.StatusUnauthorized)
 			return
 		}
 
-		next(w, r)
+		ctx := context.WithValue(r.Context(), authenticatedUserIDKey, userID)
+		next(w, r.WithContext(ctx))
 	}
 }

--- a/database/UserRepo.go
+++ b/database/UserRepo.go
@@ -144,10 +144,15 @@ func GetUserParticipant(db *sql.DB, userId int, groupId int) (models.Participant
 	FROM Participants WHERE user_id = ? AND group_id = ?;`
 	row := db.QueryRow(sqlStmt, userId, groupId)
 	var joinedAtValue any
+	var friendUserID sql.NullInt64
 
-	err := row.Scan(&participant.GroupID, &participant.UserID, &joinedAtValue, &participant.FriendUserID)
+	err := row.Scan(&participant.GroupID, &participant.UserID, &joinedAtValue, &friendUserID)
 	if err != nil {
 		return participant, err
+	}
+
+	if friendUserID.Valid {
+		participant.FriendUserID = int(friendUserID.Int64)
 	}
 
 	participant.JoinedAt, err = parseDBTime(joinedAtValue)


### PR DESCRIPTION
## Summary

Implements the `GET /group/{id}/friend` endpoint that was registered in routing but had an empty handler body (issue #9).

## Changes

- **`controllers/middleware.go`** — `BearerAuth` now stores the validated user ID in request context via a typed key; adds `authenticatedUserIDFromRequest` helper so handlers can read it.
- **`controllers/group.go`** — `GetSecretFriend` is fully implemented: validates the group ID, resolves the caller's identity from context, checks membership, checks whether the draw has been run, then returns the assigned friend's public profile (password omitted).
- **`database/UserRepo.go`** — `GetUserParticipant` now scans `friend_user_id` as `sql.NullInt64` so a NULL (draw not yet run) no longer causes a scan error.
- **`controllers/group_friend_test.go`** — New contract tests covering:
  - ✅ Success — returns assigned friend (password omitted)
  - 403 — user is not a participant of the group
  - 409 — user is a participant but draw has not been run yet

## Acceptance criteria

- [x] Endpoint has deterministic behavior
- [x] Tests cover success, not-member, and not-drawn cases

Fixes #9