### PR TITLE
Enforce Bearer auth header scheme in middleware

### DIFF
--- a/controllers/middleware.go
+++ b/controllers/middleware.go
@@ -30,6 +30,11 @@ func BearerAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		userID, err := auth.ValidateToken(token)
 		if err != nil {

--- a/controllers/middleware_test.go
+++ b/controllers/middleware_test.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akctba/secret-santa-go-api/auth"
+)
+
+func TestBearerAuthRejectsNonBearerScheme(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	token, err := auth.CreateToken(42)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	handlerCalled := false
+	handler := BearerAuth(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Basic "+token)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	if handlerCalled {
+		t.Fatal("expected next handler not to be called")
+	}
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- validate that the `Authorization` header starts with `Bearer ` before token parsing
- return `401 Invalid token` when a non-Bearer scheme is used
- add a regression test to ensure non-Bearer schemes are rejected and the next handler is not called

## Validation
- `go test ./controllers -run TestBearerAuthRejectsNonBearerScheme`
- `go test ./...`

Closes #17