### PR TITLE
Add configurable CORS middleware for web clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This API allows users to create groups for Secret Santa, add participants to the
     go run main.go
     ```
 
+### Environment Variables
+
+- `JWT_SECRET`: Optional secret used to sign bearer tokens.
+- `CORS_ALLOWED_ORIGINS`: Comma-separated list of allowed web origins for CORS (for example: `http://localhost:3000,https://app.example.com`).
+    If this is not set, cross-origin browser requests are disabled.
+
 3. The API will be available at `http://localhost:8080`.
 
 ### Running Tests

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24
 	golang.org/x/crypto v0.29.0
 )
+
+require github.com/rs/cors v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/akctba/secret-santa-go-api/database"
@@ -10,6 +12,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/gorilla/mux"
+	"github.com/rs/cors"
 )
 
 func main() {
@@ -17,10 +20,11 @@ func main() {
 
 	r := mux.NewRouter()
 	routes.Register(r)
+	handler := corsHandler(r)
 
 	server := &http.Server{
 		Addr:         ":8080",
-		Handler:      r,
+		Handler:      handler,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,
@@ -29,4 +33,41 @@ func main() {
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("server failed: %v", err)
 	}
+}
+
+func corsHandler(next http.Handler) http.Handler {
+	allowedOrigins := parseAllowedOrigins(os.Getenv("CORS_ALLOWED_ORIGINS"))
+	if len(allowedOrigins) == 0 {
+		log.Print("CORS_ALLOWED_ORIGINS not set; cross-origin browser requests are disabled")
+	}
+
+	return cors.New(cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
+		AllowedHeaders:   []string{"Authorization", "Content-Type"},
+		AllowCredentials: true,
+		MaxAge:           300,
+	}).Handler(next)
+}
+
+func parseAllowedOrigins(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	origins := strings.Split(value, ",")
+	allowedOrigins := make([]string, 0, len(origins))
+	for _, origin := range origins {
+		trimmedOrigin := strings.TrimSpace(origin)
+		if trimmedOrigin == "" {
+			continue
+		}
+		allowedOrigins = append(allowedOrigins, trimmedOrigin)
+	}
+
+	if len(allowedOrigins) == 0 {
+		return nil
+	}
+
+	return allowedOrigins
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestParseAllowedOrigins(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty value",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single origin",
+			input: "http://localhost:3000",
+			want:  []string{"http://localhost:3000"},
+		},
+		{
+			name:  "multiple origins with spaces",
+			input: "http://localhost:3000, https://example.com  ,",
+			want:  []string{"http://localhost:3000", "https://example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAllowedOrigins(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseAllowedOrigins(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCorsHandlerAllowsConfiguredOriginPreflight(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
+
+	handler := corsHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/user", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Result().Header.Get("Access-Control-Allow-Origin") != "http://localhost:3000" {
+		t.Fatalf("expected Access-Control-Allow-Origin header to be set to allowed origin; status=%d headers=%v", rr.Code, rr.Result().Header)
+	}
+}
+
+func TestCorsHandlerRejectsUnknownOriginPreflight(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
+
+	handler := corsHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/user", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Result().Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("expected Access-Control-Allow-Origin header to be empty for disallowed origin")
+	}
+}


### PR DESCRIPTION
## Summary
Add CORS middleware to support browser-based web clients and handle preflight requests.

## What changed
- Added `github.com/rs/cors` middleware to server setup in `main.go`
- Added `CORS_ALLOWED_ORIGINS` env configuration (comma-separated origins)
- Added helper parsing for configured origins
- Added tests for origin parsing and preflight allow/deny behavior in `main_test.go`
- Documented CORS configuration in `README.md`

## Why
Without CORS headers and preflight handling, browser clients are blocked by same-origin policy.

Closes #23