### PR TITLE
Add refresh token authentication flow

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,13 +10,42 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const tokenTTL = 5 * time.Minute
+const (
+	accessTokenTTL  = 30 * time.Minute
+	refreshTokenTTL = 7 * 24 * time.Hour
+
+	accessTokenType  = "access"
+	refreshTokenType = "refresh"
+)
+
+type tokenClaims struct {
+	jwt.RegisteredClaims
+	TokenType string `json:"token_type"`
+}
 
 // CreateToken generates a new bearer token for the given user ID.
 func CreateToken(userID int) (string, error) {
-	claims := jwt.RegisteredClaims{
-		Subject:   strconv.Itoa(userID),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(tokenTTL)),
+	return CreateAccessToken(userID)
+}
+
+// CreateAccessToken generates a new access token for the given user ID.
+func CreateAccessToken(userID int) (string, error) {
+	return createToken(userID, accessTokenTTL, accessTokenType)
+}
+
+// CreateRefreshToken generates a new refresh token for the given user ID.
+func CreateRefreshToken(userID int) (string, error) {
+	return createToken(userID, refreshTokenTTL, refreshTokenType)
+}
+
+func createToken(userID int, ttl time.Duration, tokenType string) (string, error) {
+	claims := tokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   strconv.Itoa(userID),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+		TokenType: tokenType,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -31,7 +60,17 @@ func CreateToken(userID int) (string, error) {
 // ValidateToken checks that a token is valid and not expired.
 // It returns the associated user ID on success.
 func ValidateToken(token string) (int, error) {
-	claims := &jwt.RegisteredClaims{}
+	return validateTokenType(token, accessTokenType)
+}
+
+// ValidateRefreshToken checks that a refresh token is valid and not expired.
+// It returns the associated user ID on success.
+func ValidateRefreshToken(token string) (int, error) {
+	return validateTokenType(token, refreshTokenType)
+}
+
+func validateTokenType(token string, expectedType string) (int, error) {
+	claims := &tokenClaims{}
 	parsedToken, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (any, error) {
 		if t.Method != jwt.SigningMethodHS256 {
 			return nil, errors.New("unexpected signing method")
@@ -43,6 +82,10 @@ func ValidateToken(token string) (int, error) {
 	}
 
 	if !parsedToken.Valid {
+		return 0, errors.New("invalid token")
+	}
+
+	if claims.TokenType != expectedType {
 		return 0, errors.New("invalid token")
 	}
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -38,9 +38,12 @@ func TestValidateTokenInvalidToken(t *testing.T) {
 func TestValidateTokenExpiredToken(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 
-	claims := jwt.RegisteredClaims{
-		Subject:   strconv.Itoa(7),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
+	claims := tokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   strconv.Itoa(7),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
+		},
+		TokenType: accessTokenType,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString(signingKey())
@@ -50,6 +53,37 @@ func TestValidateTokenExpiredToken(t *testing.T) {
 
 	if _, err := ValidateToken(tokenString); err == nil {
 		t.Fatal("ValidateToken expected error for expired token")
+	}
+}
+
+func TestValidateTokenRejectsRefreshToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	refreshToken, err := CreateRefreshToken(42)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken returned error: %v", err)
+	}
+
+	if _, err := ValidateToken(refreshToken); err == nil {
+		t.Fatal("ValidateToken expected error for refresh token")
+	}
+}
+
+func TestCreateAndValidateRefreshToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	refreshToken, err := CreateRefreshToken(42)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken returned error: %v", err)
+	}
+
+	userID, err := ValidateRefreshToken(refreshToken)
+	if err != nil {
+		t.Fatalf("ValidateRefreshToken returned error: %v", err)
+	}
+
+	if userID != 42 {
+		t.Fatalf("ValidateRefreshToken returned %d, want 42", userID)
 	}
 }
 

--- a/controllers/request_validation_test.go
+++ b/controllers/request_validation_test.go
@@ -41,6 +41,38 @@ func TestSigninReturnsBadRequestForMissingFields(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenReturnsBadRequestForMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/user/refresh", strings.NewReader(`{"refresh_token":"abc"`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	RefreshToken(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "Invalid request body") {
+		t.Fatalf("expected invalid body error, got: %s", rr.Body.String())
+	}
+}
+
+func TestRefreshTokenReturnsBadRequestForMissingField(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/user/refresh", strings.NewReader(`{"refresh_token":""}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	RefreshToken(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if !strings.Contains(rr.Body.String(), "refresh_token is required") {
+		t.Fatalf("expected missing field error, got: %s", rr.Body.String())
+	}
+}
+
 func TestCreateGroupReturnsBadRequestForMalformedJSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/group", strings.NewReader(`{"name":"xmas"`))
 	req.Header.Set("Content-Type", "application/json")

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -21,6 +21,19 @@ type createUserRequest struct {
 	Password string `json:"password"`
 }
 
+type refreshTokenRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+type signinResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type refreshTokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
 type userResponse struct {
 	UserID      int       `json:"user_id"`
 	UserName    string    `json:"user_name"`
@@ -41,7 +54,7 @@ func toUserResponse(user models.User) userResponse {
 	return resp
 }
 
-// Signin handles POST /user/signin. Validates credentials and returns a bearer token.
+// Signin handles POST /user/signin. Validates credentials and returns access and refresh tokens.
 func Signin(w http.ResponseWriter, r *http.Request) {
 	var request models.UserSignin
 	if err := decodeRequestJSON(r, &request); err != nil {
@@ -79,14 +92,53 @@ func Signin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := auth.CreateToken(user.UserID)
+	accessToken, err := auth.CreateAccessToken(user.UserID)
+	if err != nil {
+		http.Error(w, "Failed to generate token", http.StatusInternalServerError)
+		return
+	}
+
+	refreshToken, err := auth.CreateRefreshToken(user.UserID)
 	if err != nil {
 		http.Error(w, "Failed to generate token", http.StatusInternalServerError)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(token)
+	json.NewEncoder(w).Encode(signinResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+	})
+}
+
+// RefreshToken handles POST /user/refresh. Validates a refresh token and returns a new access token.
+func RefreshToken(w http.ResponseWriter, r *http.Request) {
+	var request refreshTokenRequest
+	if err := decodeRequestJSON(r, &request); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	refreshToken := strings.TrimSpace(request.RefreshToken)
+	if refreshToken == "" {
+		http.Error(w, "refresh_token is required", http.StatusBadRequest)
+		return
+	}
+
+	userID, err := auth.ValidateRefreshToken(refreshToken)
+	if err != nil {
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	accessToken, err := auth.CreateAccessToken(userID)
+	if err != nil {
+		http.Error(w, "Failed to generate token", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(refreshTokenResponse{AccessToken: accessToken})
 }
 
 // CreateUser handles POST /user. Hashes the password and persists the new user.

--- a/controllers/user_contract_test.go
+++ b/controllers/user_contract_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/akctba/secret-santa-go-api/auth"
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func setupUserContractTestDB(t *testing.T) *sql.DB {
@@ -106,5 +108,103 @@ func TestGetUserResponseOmitsPassword(t *testing.T) {
 	payload := decodeJSONBody(t, rr.Body.String())
 	if _, ok := payload["password"]; ok {
 		t.Fatalf("expected response to omit password, got: %s", rr.Body.String())
+	}
+}
+
+func TestSigninResponseReturnsAccessAndRefreshTokens(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	db := setupUserContractTestDB(t)
+	withTestDB(t, db)
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("secret123"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO Users (user_id, user_name, user_email, password) VALUES (1, 'Alice', 'alice@example.com', ?)`, string(hashedPassword)); err != nil {
+		t.Fatalf("insert test user: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/signin", strings.NewReader(`{"email":"alice@example.com","password":"secret123"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	Signin(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONBody(t, rr.Body.String())
+	accessToken, ok := payload["access_token"].(string)
+	if !ok || accessToken == "" {
+		t.Fatalf("expected access_token in response, got: %s", rr.Body.String())
+	}
+
+	refreshToken, ok := payload["refresh_token"].(string)
+	if !ok || refreshToken == "" {
+		t.Fatalf("expected refresh_token in response, got: %s", rr.Body.String())
+	}
+
+	if _, err := auth.ValidateToken(accessToken); err != nil {
+		t.Fatalf("ValidateToken returned error: %v", err)
+	}
+
+	if _, err := auth.ValidateRefreshToken(refreshToken); err != nil {
+		t.Fatalf("ValidateRefreshToken returned error: %v", err)
+	}
+}
+
+func TestRefreshTokenReturnsNewAccessToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	refreshToken, err := auth.CreateRefreshToken(42)
+	if err != nil {
+		t.Fatalf("CreateRefreshToken returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/refresh", strings.NewReader(`{"refresh_token":"`+refreshToken+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	RefreshToken(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	payload := decodeJSONBody(t, rr.Body.String())
+	accessToken, ok := payload["access_token"].(string)
+	if !ok || accessToken == "" {
+		t.Fatalf("expected access_token in response, got: %s", rr.Body.String())
+	}
+
+	userID, err := auth.ValidateToken(accessToken)
+	if err != nil {
+		t.Fatalf("ValidateToken returned error: %v", err)
+	}
+
+	if userID != 42 {
+		t.Fatalf("ValidateToken returned %d, want 42", userID)
+	}
+}
+
+func TestRefreshTokenRejectsAccessToken(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	accessToken, err := auth.CreateAccessToken(42)
+	if err != nil {
+		t.Fatalf("CreateAccessToken returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/refresh", strings.NewReader(`{"refresh_token":"`+accessToken+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	RefreshToken(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusUnauthorized, rr.Code, rr.Body.String())
 	}
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -10,6 +10,7 @@ func Register(r *mux.Router) {
 	// User endpoints
 	r.HandleFunc("/user", controllers.CreateUser).Methods("POST")
 	r.HandleFunc("/user/signin", controllers.Signin).Methods("POST")
+	r.HandleFunc("/user/refresh", controllers.RefreshToken).Methods("POST")
 	r.HandleFunc("/user/{id}", controllers.BearerAuth(controllers.GetUser)).Methods("GET")
 
 	// Group endpoints


### PR DESCRIPTION
## Summary
Add refresh token support to the authentication flow so clients can renew access without forcing users to sign in again every few minutes.

## Changes
- increase access token lifetime and distinguish access vs refresh token validation
- return both `access_token` and `refresh_token` from `POST /user/signin`
- add `POST /user/refresh` to exchange a valid refresh token for a new access token
- add auth and controller tests for refresh token validation and response contracts

Fixes #24